### PR TITLE
Remove NAME variable from app paths

### DIFF
--- a/MacDVDRipperPro/MDRP.download.recipe
+++ b/MacDVDRipperPro/MDRP.download.recipe
@@ -58,7 +58,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>input_path</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/Applications/MDRP.app</string>
 				<key>requirement</key>
 				<string>anchor apple generic and identifier "com.mdrp.MDRP" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "8CE859W3R2")</string>
 			</dict>

--- a/MacDVDRipperPro/MDRP.munki.recipe
+++ b/MacDVDRipperPro/MDRP.munki.recipe
@@ -42,7 +42,7 @@
 				<key>dmg_megabytes</key>
 				<string>700</string>
 				<key>dmg_root</key>
-				<string>%RECIPE_CACHE_DIR%/downloads/Applications/%NAME%.app</string>
+				<string>%RECIPE_CACHE_DIR%/downloads/Applications/MDRP.app</string>
 				<key>dmg_path</key>
 				<string>%RECIPE_CACHE_DIR%/%NAME%.dmg</string>
 			</dict>


### PR DESCRIPTION
Because variables can be overridden, it's a good idea to make sure that the recipe will still work even if a non-default variables used. One issue that would prevent recipes from running is using a `NAME` variable in paths that should be hard-coded (e.g. `/Applications/Foo.app`).

This PR removes the `NAME` variable from all file paths and replaces it with the actual app name, which should make the recipe more resilient for overrides.