### PR TITLE
Deprecate Final Cut Library Manager recipes

### DIFF
--- a/FinalCutLibraryManager/FinalCutLibraryManager.download.recipe
+++ b/FinalCutLibraryManager/FinalCutLibraryManager.download.recipe
@@ -14,7 +14,7 @@
 		<string>https://www.arcticwhiteness.com/finalcutlibrarymanager/download/appcast.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>0.4.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
 		<dict>

--- a/FinalCutLibraryManager/FinalCutLibraryManager.download.recipe
+++ b/FinalCutLibraryManager/FinalCutLibraryManager.download.recipe
@@ -19,6 +19,15 @@
 	<array>
 		<dict>
 			<key>Processor</key>
+			<string>DeprecationWarning</string>
+			<key>Arguments</key>
+			<dict>
+				<key>warning_message</key>
+				<string>Final Cut Library Manager is now called Arctic. Consider switching to the Arctic recipes in the dataJAR-recipes repo. This recipe is deprecated and will be removed in the future.</string>
+			</dict>
+		</dict>
+		<dict>
+			<key>Processor</key>
 			<string>SparkleUpdateInfoProvider</string>
 			<key>Arguments</key>
 			<dict>


### PR DESCRIPTION
Final Cut Library Manager is now called Arctic ([details](https://www.arcticwhiteness.com/finalcutlibrarymanager/)), and the previous Sparkle feed has been broken with the latest entry. This PR deprecates the Final Cut Library Manager recipes.