### PR TITLE
Update the Sparkle feed for Project X27

### DIFF
--- a/X27/X27.download.recipe
+++ b/X27/X27.download.recipe
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the current release version of X27.</string>
+	<string>Downloads the current release version of XtoCC, also known as X27.</string>
 	<key>Identifier</key>
 	<string>com.github.autopkg.macvfx.download.X27</string>
 	<key>Input</key>
@@ -11,7 +11,7 @@
 		<key>NAME</key>
 		<string>X27</string>
 		<key>SPARKLE_FEED_URL</key>
-		<string>http://www.assistedediting.com/appcast/projectXto7.xml</string>
+		<string>https://intelligentassistance.com/appcast/projectXto7.xml</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>0.4.0</string>
@@ -32,7 +32,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>filename</key>
-				<string>%NAME%.zip</string>
+				<string>%NAME%-%version%.zip</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
This PR updates the Sparkle feed used to download the XtoCC (aka Project X27) software.

Verbose recipe run output:

```
% autopkg run -vvq 'X27/X27.download.recipe'
Processing X27/X27.download.recipe...
WARNING: X27/X27.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://intelligentassistance.com/appcast/projectXto7.xml'}}
SparkleUpdateInfoProvider: Items in feed: 166
SparkleUpdateInfoProvider: Items in default channel: 166
SparkleUpdateInfoProvider: Version retrieved from appcast: 12460
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 1.2.46
SparkleUpdateInfoProvider: Found URL https://intelligentassistance.com/downloads/Project%20Xto7.zip
{'Output': {'url': 'https://intelligentassistance.com/downloads/Project%20Xto7.zip',
            'version': '1.2.46'}}
URLDownloader
{'Input': {'filename': 'X27-1.2.46.zip',
           'url': 'https://intelligentassistance.com/downloads/Project%20Xto7.zip'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Mon, 14 Oct 2024 19:58:29 GMT
URLDownloader: Storing new ETag header: "6401d4-6247542b20340"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.autopkg.macvfx.download.X27/downloads/X27-1.2.46.zip
{'Output': {'download_changed': True,
            'etag': '"6401d4-6247542b20340"',
            'last_modified': 'Mon, 14 Oct 2024 19:58:29 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.autopkg.macvfx.download.X27/downloads/X27-1.2.46.zip',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.autopkg.macvfx.download.X27/downloads/X27-1.2.46.zip'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
Unarchiver
{'Input': {'archive_path': '~/Library/AutoPkg/Cache/com.github.autopkg.macvfx.download.X27/downloads/X27-1.2.46.zip',
           'destination_path': '~/Library/AutoPkg/Cache/com.github.autopkg.macvfx.download.X27/downloads/Applications',
           'purge_destination': True}}
Unarchiver: No value supplied for USE_PYTHON_NATIVE_EXTRACTOR, setting default value of: False
Unarchiver: Guessed archive format 'zip' from filename X27-1.2.46.zip
Unarchiver: Unarchived ~/Library/AutoPkg/Cache/com.github.autopkg.macvfx.download.X27/downloads/X27-1.2.46.zip to ~/Library/AutoPkg/Cache/com.github.autopkg.macvfx.download.X27/downloads/Applications
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.github.autopkg.macvfx.download.X27/downloads/Applications/Project '
                         'X₂7.app',
           'requirement': 'identifier "com.AssistedEditing.ProjectXto7" and '
                          'anchor apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          'BEZQTYWJB6'}}
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.autopkg.macvfx.download.X27/downloads/Applications/Project X₂7.app: valid on disk
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.autopkg.macvfx.download.X27/downloads/Applications/Project X₂7.app: satisfies its Designated Requirement
CodeSignatureVerifier: ~/Library/AutoPkg/Cache/com.github.autopkg.macvfx.download.X27/downloads/Applications/Project X₂7.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.autopkg.macvfx.download.X27/receipts/X27.download-receipt-20241224-201554.plist

The following new items were downloaded:
    Download Path                                                                                        
    -------------                                                                                        
    ~/Library/AutoPkg/Cache/com.github.autopkg.macvfx.download.X27/downloads/X27-1.2.46.zip
```