### PR TITLE
Update Sparkle feed and code signing requirements for Postlab

### DIFF
--- a/Postlab/Postlab.download.recipe
+++ b/Postlab/Postlab.download.recipe
@@ -21,7 +21,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>appcast_url</key>
-				<string>https://sparkle.postlab.cloud/postlab/macos/appcast/postlab-prod.xml</string>
+				<string>https://updates.hedge.video/postlab/macos/appcast/postlab-prod.xml</string>
 			</dict>
 			<key>Processor</key>
 			<string>SparkleUpdateInfoProvider</string>
@@ -44,7 +44,13 @@
 			<dict>
 				<key>input_path</key>
 				<string>%pathname%/Postlab Installer.pkg</string>
-				</dict>
+				<key>expected_authority_names</key>
+				<array>
+					<string>Developer ID Installer: The Sync Factory (A43D9X8EYU)</string>
+					<string>Developer ID Certification Authority</string>
+					<string>Apple Root CA</string>
+				</array>
+			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>
 		</dict>


### PR DESCRIPTION
This PR adjusts the Sparkle feed URL for Postlab and adds expected authority names for the installer package.

Verbose recipe run output:

```
% autopkg run -vvq 'Postlab/Postlab.download.recipe'
Processing Postlab/Postlab.download.recipe...
WARNING: Postlab/Postlab.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
SparkleUpdateInfoProvider
{'Input': {'appcast_url': 'https://updates.hedge.video/postlab/macos/appcast/postlab-prod.xml'}}
SparkleUpdateInfoProvider: Items in feed: 14
SparkleUpdateInfoProvider: Items in default channel: 14
SparkleUpdateInfoProvider: Version retrieved from appcast: 134
SparkleUpdateInfoProvider: User-facing version retrieved from appcast: 24.0.18
SparkleUpdateInfoProvider: Found URL https://updates.hedge.video/postlab/macos/updates/production/PostLab_20241127134545_v24.0.18b134/PostLab_20241127134545_v24.0.18b134.dmg
{'Output': {'url': 'https://updates.hedge.video/postlab/macos/updates/production/PostLab_20241127134545_v24.0.18b134/PostLab_20241127134545_v24.0.18b134.dmg',
            'version': '24.0.18'}}
URLDownloader
{'Input': {'filename': 'Postlab-24.0.18.dmg',
           'url': 'https://updates.hedge.video/postlab/macos/updates/production/PostLab_20241127134545_v24.0.18b134/PostLab_20241127134545_v24.0.18b134.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Thu, 28 Nov 2024 08:13:26 GMT
URLDownloader: Storing new ETag header: "4ebdfe28c9c78b46fe3e139be62d641f"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/org.macvfx.download.Postlab/downloads/Postlab-24.0.18.dmg
{'Output': {'download_changed': True,
            'etag': '"4ebdfe28c9c78b46fe3e139be62d641f"',
            'last_modified': 'Thu, 28 Nov 2024 08:13:26 GMT',
            'pathname': '~/Library/AutoPkg/Cache/org.macvfx.download.Postlab/downloads/Postlab-24.0.18.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/org.macvfx.download.Postlab/downloads/Postlab-24.0.18.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'expected_authority_names': ['Developer ID Installer: The Sync '
                                        'Factory (A43D9X8EYU)',
                                        'Developer ID Certification Authority',
                                        'Apple Root CA'],
           'input_path': '~/Library/AutoPkg/Cache/org.macvfx.download.Postlab/downloads/Postlab-24.0.18.dmg/Postlab '
                         'Installer.pkg'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/org.macvfx.download.Postlab/downloads/Postlab-24.0.18.dmg
CodeSignatureVerifier: Verifying installer package signature...
CodeSignatureVerifier: Package "PostLab Installer.pkg":
CodeSignatureVerifier:    Status: signed by a developer certificate issued by Apple for distribution
CodeSignatureVerifier:    Notarization: trusted by the Apple notary service
CodeSignatureVerifier:    Signed with a trusted timestamp on: 2024-11-27 12:50:29 +0000
CodeSignatureVerifier:    Certificate Chain:
CodeSignatureVerifier:     1. Developer ID Installer: The Sync Factory (A43D9X8EYU)
CodeSignatureVerifier:        Expires: 2025-06-06 08:24:34 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            5C 55 D3 EF 6B 57 8E 50 BA 2D 6A A4 A7 50 AA 34 7C 50 D9 B5 EE AC
CodeSignatureVerifier:            D9 79 6E E3 72 EC B1 7D 5C E7
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     2. Developer ID Certification Authority
CodeSignatureVerifier:        Expires: 2027-02-01 22:12:15 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            7A FC 9D 01 A6 2F 03 A2 DE 96 37 93 6D 4A FE 68 09 0D 2D E1 8D 03
CodeSignatureVerifier:            F2 9C 88 CF B0 B1 BA 63 58 7F
CodeSignatureVerifier:        ------------------------------------------------------------------------
CodeSignatureVerifier:     3. Apple Root CA
CodeSignatureVerifier:        Expires: 2035-02-09 21:40:36 +0000
CodeSignatureVerifier:        SHA256 Fingerprint:
CodeSignatureVerifier:            B0 B1 73 0E CB C7 FF 45 05 14 2C 49 F1 29 5E 6E DA 6B CA ED 7E 2C
CodeSignatureVerifier:            68 C5 BE 91 B5 A1 10 01 F0 24
CodeSignatureVerifier:
CodeSignatureVerifier: Signature is valid
CodeSignatureVerifier: Authority name chain is valid
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/org.macvfx.download.Postlab/receipts/Postlab.download-receipt-20241228-220134.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/org.macvfx.download.Postlab/downloads/Postlab-24.0.18.dmg
```