### PR TITLE
Deprecate Archiware P5 Archive App recipes and add P5 Companion recipes

### DIFF
--- a/Archiware/P5 Archive App.download.recipe
+++ b/Archiware/P5 Archive App.download.recipe
@@ -16,9 +16,18 @@
 		<string>P5 Archive App</string>
 	</dict>
 	<key>MinimumVersion</key>
-	<string>1.0.0</string>
+	<string>1.1</string>
 	<key>Process</key>
 	<array>
+        <dict>
+            <key>Processor</key>
+            <string>DeprecationWarning</string>
+            <key>Arguments</key>
+            <dict>
+                <key>warning_message</key>
+                <string>P5 Archive App is no longer supported by Archiware. Consider switching to the P5 Companion recipes in this repo. This recipe is deprecated and will be removed in the future.</string>
+            </dict>
+        </dict>
 		<dict>
 			<key>Arguments</key>
 			<dict>

--- a/Archiware/P5Companion.download.recipe
+++ b/Archiware/P5Companion.download.recipe
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of P5 Companion.</string>
+	<key>Identifier</key>
+	<string>com.macvfx.download.P5Companion</string>
+	<key>Input</key>
+	<dict>
+		<key>NAME</key>
+		<string>P5Companion</string>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>re_pattern</key>
+				<string>start-p5\.php\?platform=companion_mac&amp;amp;release=P5-Companion-([\d\.]+)\.dmg"</string>
+				<key>result_output_var_name</key>
+				<string>version</string>
+				<key>url</key>
+				<string>https://www.archiware.com/download-p5</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLTextSearcher</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>url</key>
+				<string>https://p5-downloads.s3.amazonaws.com/P5-Companion-%version%.dmg</string>
+				<key>file</key>
+				<string>%NAME%-%version%.dmg</string>
+			</dict>
+			<key>Processor</key>
+			<string>URLDownloader</string>
+		</dict>
+		<dict>
+			<key>Processor</key>
+			<string>EndOfCheckPhase</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_path</key>
+				<string>%pathname%/P5 Companion.app</string>
+				<key>requirement</key>
+				<string>identifier "com.Archiware.P5Companion" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "5H5EU6F965"</string>
+			</dict>
+			<key>Processor</key>
+			<string>CodeSignatureVerifier</string>
+		</dict>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>input_plist_path</key>
+				<string>%pathname%/P5 Companion.app/Contents/Info.plist</string>
+				<key>plist_version_key</key>
+				<string>CFBundleShortVersionString</string>
+			</dict>
+			<key>Processor</key>
+			<string>Versioner</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Archiware/P5Companion.munki.recipe
+++ b/Archiware/P5Companion.munki.recipe
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Description</key>
+	<string>Downloads the latest version of P5 Companion and imports it into Munki.</string>
+	<key>Identifier</key>
+	<string>com.macvfx.munki.P5Companion</string>
+	<key>Input</key>
+	<dict>
+		<key>MUNKI_REPO_SUBDIR</key>
+		<string>apps/%NAME%</string>
+		<key>NAME</key>
+		<string>P5Companion</string>
+		<key>pkginfo</key>
+		<dict>
+			<key>catalogs</key>
+			<array>
+				<string>testing</string>
+			</array>
+			<key>description</key>
+			<string>P5 Companion is a desktop application for Windows, macOS and Linux that allows files from either local or shared storage to be archived restored by simple drag-and-drop operations. Data is archived and restored via communication with a P5 Server running the P5 Archive software.</string>
+			<key>developer</key>
+			<string>Archiware GmbH</string>
+			<key>display_name</key>
+			<string>P5 Companion</string>
+			<key>name</key>
+			<string>%NAME%</string>
+			<key>unattended_install</key>
+			<true/>
+		</dict>
+	</dict>
+	<key>MinimumVersion</key>
+	<string>1.0.0</string>
+	<key>ParentRecipe</key>
+	<string>com.macvfx.download.P5Companion</string>
+	<key>Process</key>
+	<array>
+		<dict>
+			<key>Arguments</key>
+			<dict>
+				<key>pkg_path</key>
+				<string>%pathname%</string>
+				<key>repo_subdirectory</key>
+				<string>%MUNKI_REPO_SUBDIR%</string>
+			</dict>
+			<key>Processor</key>
+			<string>MunkiImporter</string>
+		</dict>
+	</array>
+</dict>
+</plist>


### PR DESCRIPTION
This PR deprecates the Archiware P5 Archive App recipes, since that app is no longer maintained. In their place, I've included new recipes for the P5 Companion app, its functional successor.

Verbose recipe run output:

```
% autopkg run -vvq P5Companion.*.recipe
Processing P5Companion.download.recipe...
WARNING: P5Companion.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'start-p5\\.php\\?platform=companion_mac&amp;release=P5-Companion-([\\d\\.]+)\\.dmg"',
           'result_output_var_name': 'version',
           'url': 'https://www.archiware.com/download-p5'}}
URLTextSearcher: Found matching text (version): 1.1.1
{'Output': {'version': '1.1.1'}}
URLDownloader
{'Input': {'url': 'https://p5-downloads.s3.amazonaws.com/P5-Companion-1.1.1.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 27 Jul 2021 08:44:46 GMT
URLDownloader: Storing new ETag header: "447c4f548fa8404155803e3bc3167676-5"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.macvfx.download.P5Companion/downloads/P5-Companion-1.1.1.dmg
{'Output': {'download_changed': True,
            'etag': '"447c4f548fa8404155803e3bc3167676-5"',
            'last_modified': 'Tue, 27 Jul 2021 08:44:46 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.macvfx.download.P5Companion/downloads/P5-Companion-1.1.1.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.macvfx.download.P5Companion/downloads/P5-Companion-1.1.1.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.macvfx.download.P5Companion/downloads/P5-Companion-1.1.1.dmg/P5 '
                         'Companion.app',
           'requirement': 'identifier "com.Archiware.P5Companion" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"5H5EU6F965"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.macvfx.download.P5Companion/downloads/P5-Companion-1.1.1.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.JQV5Qr/P5 Companion.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.JQV5Qr/P5 Companion.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.JQV5Qr/P5 Companion.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.macvfx.download.P5Companion/downloads/P5-Companion-1.1.1.dmg/P5 '
                               'Companion.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.macvfx.download.P5Companion/downloads/P5-Companion-1.1.1.dmg
Versioner: Found version 1.1.1 in file ~/Library/AutoPkg/Cache/com.macvfx.download.P5Companion/downloads/P5-Companion-1.1.1.dmg/P5 Companion.app/Contents/Info.plist
{'Output': {'version': '1.1.1'}}
Receipt written to ~/Library/AutoPkg/Cache/com.macvfx.download.P5Companion/receipts/P5Companion.download-receipt-20241228-214423.plist
Processing P5Companion.munki.recipe...
WARNING: P5Companion.munki.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'start-p5\\.php\\?platform=companion_mac&amp;release=P5-Companion-([\\d\\.]+)\\.dmg"',
           'result_output_var_name': 'version',
           'url': 'https://www.archiware.com/download-p5'}}
URLTextSearcher: Found matching text (version): 1.1.1
{'Output': {'version': '1.1.1'}}
URLDownloader
{'Input': {'url': 'https://p5-downloads.s3.amazonaws.com/P5-Companion-1.1.1.dmg'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Tue, 27 Jul 2021 08:44:46 GMT
URLDownloader: Storing new ETag header: "447c4f548fa8404155803e3bc3167676-5"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.macvfx.munki.P5Companion/downloads/P5-Companion-1.1.1.dmg
{'Output': {'download_changed': True,
            'etag': '"447c4f548fa8404155803e3bc3167676-5"',
            'last_modified': 'Tue, 27 Jul 2021 08:44:46 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.macvfx.munki.P5Companion/downloads/P5-Companion-1.1.1.dmg',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.macvfx.munki.P5Companion/downloads/P5-Companion-1.1.1.dmg'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
CodeSignatureVerifier
{'Input': {'input_path': '~/Library/AutoPkg/Cache/com.macvfx.munki.P5Companion/downloads/P5-Companion-1.1.1.dmg/P5 '
                         'Companion.app',
           'requirement': 'identifier "com.Archiware.P5Companion" and anchor '
                          'apple generic and certificate '
                          '1[field.1.2.840.113635.100.6.2.6] /* exists */ and '
                          'certificate leaf[field.1.2.840.113635.100.6.1.13] '
                          '/* exists */ and certificate leaf[subject.OU] = '
                          '"5H5EU6F965"'}}
CodeSignatureVerifier: Mounted disk image ~/Library/AutoPkg/Cache/com.macvfx.munki.P5Companion/downloads/P5-Companion-1.1.1.dmg
CodeSignatureVerifier: Verifying code signature...
CodeSignatureVerifier: Deep verification enabled...
CodeSignatureVerifier: Strict verification not defined. Using codesign defaults...
CodeSignatureVerifier: /private/tmp/dmg.6ZcFOg/P5 Companion.app: valid on disk
CodeSignatureVerifier: /private/tmp/dmg.6ZcFOg/P5 Companion.app: satisfies its Designated Requirement
CodeSignatureVerifier: /private/tmp/dmg.6ZcFOg/P5 Companion.app: explicit requirement satisfied
CodeSignatureVerifier: Signature is valid
{'Output': {}}
Versioner
{'Input': {'input_plist_path': '~/Library/AutoPkg/Cache/com.macvfx.munki.P5Companion/downloads/P5-Companion-1.1.1.dmg/P5 '
                               'Companion.app/Contents/Info.plist',
           'plist_version_key': 'CFBundleShortVersionString'}}
Versioner: No value supplied for skip_single_root_dir, setting default value of: False
Versioner: Mounted disk image ~/Library/AutoPkg/Cache/com.macvfx.munki.P5Companion/downloads/P5-Companion-1.1.1.dmg
Versioner: Found version 1.1.1 in file ~/Library/AutoPkg/Cache/com.macvfx.munki.P5Companion/downloads/P5-Companion-1.1.1.dmg/P5 Companion.app/Contents/Info.plist
{'Output': {'version': '1.1.1'}}
MunkiImporter
{'Input': {'MUNKI_REPO': '/Users/Shared/munki_repo',
           'pkg_path': '~/Library/AutoPkg/Cache/com.macvfx.munki.P5Companion/downloads/P5-Companion-1.1.1.dmg',
           'pkginfo': {'catalogs': ['testing'],
                       'description': 'P5 Companion is a desktop application '
                                      'for Windows, macOS and Linux that '
                                      'allows files from either local or '
                                      'shared storage to be archived restored '
                                      'by simple drag-and-drop operations. '
                                      'Data is archived and restored via '
                                      'communication with a P5 Server running '
                                      'the P5 Archive software.',
                       'developer': 'Archiware GmbH',
                       'display_name': 'P5 Companion',
                       'name': 'P5Companion',
                       'unattended_install': True},
           'repo_subdirectory': 'apps/P5Companion'}}
MunkiImporter: No value supplied for MUNKI_REPO_PLUGIN, setting default value of: FileRepo
MunkiImporter: No value supplied for MUNKILIB_DIR, setting default value of: /usr/local/munki
MunkiImporter: No value supplied for force_munki_repo_lib, setting default value of: False
MunkiImporter: Using repo lib: AutoPkgLib
MunkiImporter:         plugin: FileRepo
MunkiImporter:           repo: /Users/Shared/munki_repo
MunkiImporter: Copied pkginfo to: /Users/Shared/munki_repo/pkgsinfo/apps/P5Companion/P5Companion-1.1.1.plist
MunkiImporter:            pkg to: /Users/Shared/munki_repo/pkgs/apps/P5Companion/P5-Companion-1.1.1.dmg
{'Output': {'munki_importer_summary_result': {'data': {'catalogs': 'testing',
                                                       'icon_repo_path': '',
                                                       'name': 'P5Companion',
                                                       'pkg_repo_path': 'apps/P5Companion/P5-Companion-1.1.1.dmg',
                                                       'pkginfo_path': 'apps/P5Companion/P5Companion-1.1.1.plist',
                                                       'version': '1.1.1'},
                                              'report_fields': ['name',
                                                                'version',
                                                                'catalogs',
                                                                'pkginfo_path',
                                                                'pkg_repo_path',
                                                                'icon_repo_path'],
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'imported into '
                                                              'Munki:'},
            'munki_info': {'_metadata': {'created_by': 'testuser',
                                         'creation_date': datetime.datetime(2024, 12, 29, 5, 44, 50),
                                         'munki_version': '6.6.3.4704',
                                         'os_version': '15.2'},
                           'autoremove': False,
                           'catalogs': ['testing'],
                           'description': 'P5 Companion is a desktop '
                                          'application for Windows, macOS and '
                                          'Linux that allows files from either '
                                          'local or shared storage to be '
                                          'archived restored by simple '
                                          'drag-and-drop operations. Data is '
                                          'archived and restored via '
                                          'communication with a P5 Server '
                                          'running the P5 Archive software.',
                           'developer': 'Archiware GmbH',
                           'display_name': 'P5 Companion',
                           'installer_item_hash': '342b7e98c00ea731c747b19ae89ede4d1147e46ba196bc0697c2751273f12ac4',
                           'installer_item_location': 'apps/P5Companion/P5-Companion-1.1.1.dmg',
                           'installer_item_size': 69137,
                           'installer_type': 'copy_from_dmg',
                           'installs': [{'CFBundleIdentifier': 'com.Archiware.P5Companion',
                                         'CFBundleName': 'P5 Companion',
                                         'CFBundleShortVersionString': '1.1.1',
                                         'CFBundleVersion': '1.1.1',
                                         'minosversion': '10.10.0',
                                         'path': '/Applications/P5 '
                                                 'Companion.app',
                                         'type': 'application',
                                         'version_comparison_key': 'CFBundleShortVersionString'}],
                           'items_to_copy': [{'destination_path': '/Applications',
                                              'source_item': 'P5 '
                                                             'Companion.app'}],
                           'minimum_os_version': '10.10.0',
                           'name': 'P5Companion',
                           'unattended_install': True,
                           'uninstall_method': 'remove_copied_items',
                           'uninstallable': True,
                           'version': '1.1.1'},
            'munki_repo_changed': True,
            'pkg_repo_path': '/Users/Shared/munki_repo/pkgs/apps/P5Companion/P5-Companion-1.1.1.dmg',
            'pkginfo_repo_path': '/Users/Shared/munki_repo/pkgsinfo/apps/P5Companion/P5Companion-1.1.1.plist'}}
Receipt written to ~/Library/AutoPkg/Cache/com.macvfx.munki.P5Companion/receipts/P5Companion.munki-receipt-20241228-214450.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.macvfx.download.P5Companion/downloads/P5-Companion-1.1.1.dmg
    ~/Library/AutoPkg/Cache/com.macvfx.munki.P5Companion/downloads/P5-Companion-1.1.1.dmg

The following new items were imported into Munki:
    Name         Version  Catalogs  Pkginfo Path                              Pkg Repo Path                            Icon Repo Path
    ----         -------  --------  ------------                              -------------                            --------------
    P5Companion  1.1.1    testing   apps/P5Companion/P5Companion-1.1.1.plist  apps/P5Companion/P5-Companion-1.1.1.dmg
```